### PR TITLE
[fix] 블랙리스트 토큰 저장 방식 수정

### DIFF
--- a/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
@@ -95,19 +95,19 @@ public class JwtUtil {
         final String refreshTokenKey = REFRESH_TOKEN_PREFIX.concat(email);
 
         if (redisTemplate.hasKey(accessTokenKey)) {
-            blacklistToken(redisTemplate.opsForValue().get(accessTokenKey));
+            blacklistToken(redisTemplate.opsForValue().get(accessTokenKey), email);
             redisTemplate.delete(accessTokenKey);
         }
 
         if (redisTemplate.hasKey(refreshTokenKey)) {
-            blacklistToken(redisTemplate.opsForValue().get(refreshTokenKey));
+            blacklistToken(redisTemplate.opsForValue().get(refreshTokenKey), email);
             redisTemplate.delete(refreshTokenKey);
         }
     }
 
     // 토큰 블랙리스트 추가
-    public void blacklistToken(final String token) {
-        redisTemplate.opsForValue().set(BLACKLIST_PREFIX.concat(token), token, getRemainingTokenExpiration(token));
+    public void blacklistToken(final String token, final String email) {
+        redisTemplate.opsForValue().set(BLACKLIST_PREFIX.concat(token), email, getRemainingTokenExpiration(token), TimeUnit.MILLISECONDS);
     }
 
     // 토큰 블랙리스트 확인


### PR DESCRIPTION
# [fix] 블랙리스트 토큰 저장 방식 수정

## Issue
- #9 

## 구현 사항
- 블랙리스트 저장 시 Redis 데이터 생명주기를 ms 단위로 저장하도록 변경
- 토큰 소유자(사용자) 이메일을 함께 저장하도록 구현