### PR TITLE
[infra] 서버 시간대 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=build /home/gradle/project/build/libs/dmu-dasom-api.jar api.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Dspring.profiles.active=default,credentials", "-jar", "api.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=default,credentials", "-Duser.timezone=Asia/Seoul", "-jar", "api.jar"]


### PR DESCRIPTION
# [infra] 서버 시간대 설정 추가

## Issue
- #11 

## 변경 내용
- 서버 시간대, DB 시간대 설정을 KST로 통일해 시간대 관련한 문제 사전 차단

## 구현 사항
- Dockerfile 속 jar 실행 명령에 Asia/Seoul 시간대 설정 추가