### PR TITLE
[feat] 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/member/service/MemberService.java
+++ b/src/main/java/dmu/dasom/api/domain/member/service/MemberService.java
@@ -2,6 +2,8 @@ package dmu.dasom.api.domain.member.service;
 
 import dmu.dasom.api.domain.member.dto.SignupRequestDto;
 import dmu.dasom.api.domain.member.entity.Member;
+import dmu.dasom.api.global.auth.dto.TokenBox;
+import dmu.dasom.api.global.auth.userdetails.UserDetailsImpl;
 
 public interface MemberService {
 
@@ -10,5 +12,7 @@ public interface MemberService {
     boolean checkByEmail(final String email);
 
     void signUp(final SignupRequestDto request);
+
+    TokenBox tokenRotation(final UserDetailsImpl userDetails);
 
 }

--- a/src/main/java/dmu/dasom/api/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/dmu/dasom/api/domain/member/service/MemberServiceImpl.java
@@ -5,6 +5,9 @@ import dmu.dasom.api.domain.common.exception.ErrorCode;
 import dmu.dasom.api.domain.member.dto.SignupRequestDto;
 import dmu.dasom.api.domain.member.entity.Member;
 import dmu.dasom.api.domain.member.repository.MemberRepository;
+import dmu.dasom.api.global.auth.dto.TokenBox;
+import dmu.dasom.api.global.auth.jwt.JwtUtil;
+import dmu.dasom.api.global.auth.userdetails.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ public class MemberServiceImpl implements MemberService {
 
     private final BCryptPasswordEncoder encoder;
     private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
 
     // 이메일로 사용자 조회
     @Override
@@ -40,6 +44,12 @@ public class MemberServiceImpl implements MemberService {
 
         // 비밀번호 암호화 후 저장
         memberRepository.save(request.toEntity(encoder.encode(request.getPassword())));
+    }
+
+    // 토큰 갱신
+    @Override
+    public TokenBox tokenRotation(final UserDetailsImpl userDetails) {
+        return jwtUtil.tokenRotation(userDetails);
     }
 
 }

--- a/src/main/java/dmu/dasom/api/global/auth/config/SecurityConfig.java
+++ b/src/main/java/dmu/dasom/api/global/auth/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/admin/**").hasRole(Role.ROLE_ADMIN.getName())
-                        .requestMatchers("/api/auth/logout").authenticated()
+                        .requestMatchers("/api/auth/logout", "/api/auth/rotation").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(jwtFilter, CustomAuthenticationFilter.class)
                 .addFilterAt(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
@@ -3,6 +3,7 @@ package dmu.dasom.api.global.auth.jwt;
 import dmu.dasom.api.domain.common.exception.CustomException;
 import dmu.dasom.api.domain.common.exception.ErrorCode;
 import dmu.dasom.api.global.auth.dto.TokenBox;
+import dmu.dasom.api.global.auth.userdetails.UserDetailsImpl;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
 import org.springframework.beans.factory.annotation.Value;
@@ -128,6 +129,12 @@ public class JwtUtil {
         } catch (ExpiredJwtException ex) {
             return true;
         }
+    }
+
+    // Access, Refresh 토큰 갱신
+    public TokenBox tokenRotation(final UserDetailsImpl userDetails) {
+        blacklistTokens(userDetails.getUsername());
+        return generateTokenBox(userDetails.getUsername());
     }
 
 }


### PR DESCRIPTION
# [feat] 토큰 재발급 API 구현

# Issue
- #20 

## 변경 내용
- 토큰 재발급 요청 API 구현

## 구현 사항
- 토큰 재발급 경로에 대해 인증 상태 요구 -> JwtFilter를 거쳐 재발급 처리 (토큰 검증 간소화)
- 토큰 신규 발급과 동시에 이미 발급되어있는 사용자의 토큰 만료 처리 (Token Rotation)
- Response Header를 통해 토큰 응답