### PR TITLE
[fix] Google 컨트롤러와 Google 서비스 간의 의존성 추가

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
+++ b/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
@@ -11,6 +11,7 @@ import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import dmu.dasom.api.domain.common.exception.CustomException;
 import dmu.dasom.api.domain.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,13 +23,14 @@ import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
 
+@RequiredArgsConstructor
 @Service
 public class GoogleApiService {
 
     private static final Logger logger = LoggerFactory.getLogger(GoogleApiService.class);
     private static final String APPLICATION_NAME = "Recruit Form";
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-    @Value("${google.credentials.file.path}")
+    @Value("${google.credentials.path}")
     private String credentialsFilePath;
     private Sheets sheetsService;
 

--- a/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
+++ b/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
@@ -7,6 +7,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
+import com.google.auth.Credentials;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import dmu.dasom.api.domain.common.exception.CustomException;
@@ -18,7 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
@@ -30,16 +33,18 @@ public class GoogleApiService {
     private static final Logger logger = LoggerFactory.getLogger(GoogleApiService.class);
     private static final String APPLICATION_NAME = "Recruit Form";
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-    @Value("${google.credentials.path}")
-    private String credentialsFilePath;
+    @Value("${google.credentials.json}")
+    private String credentialsJson;
     private Sheets sheetsService;
 
-    // 해당 메소드는 sheets의 인스턴스를 얻는데 사용
+    // Google Sheets API 서비스 객체를 생성하는 메소드
     private Sheets getSheetsService() throws IOException, GeneralSecurityException{
         if(sheetsService == null){
+            ByteArrayInputStream credentialsStream = new ByteArrayInputStream(credentialsJson.getBytes(StandardCharsets.UTF_8));
             GoogleCredentials credentials = GoogleCredentials
-                    .fromStream(new ClassPathResource(credentialsFilePath).getInputStream())
+                    .fromStream(credentialsStream)
                     .createScoped(Collections.singletonList("https://www.googleapis.com/auth/spreadsheets"));
+
             sheetsService = new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, new HttpCredentialsAdapter(credentials))
                     .setApplicationName(APPLICATION_NAME)
                     .build();

--- a/src/main/resources/application-credentials.yml
+++ b/src/main/resources/application-credentials.yml
@@ -21,6 +21,6 @@ jwt:
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
 google:
   credentials:
-    path: ${GOOGLE_CREDENTIALS_PATH}
+    json: ${GOOGLE_CREDENTIALS_JSON}
   spreadsheet:
     id: ${GOOGLE_SPREADSHEET_ID}


### PR DESCRIPTION
# [fix] Google 컨트롤러와 Google 서비스 간의 의존성 추가

## #24 

## 변경 내용
- googleApiService 빈의 의존성 주입 과정에서 실패하여 yml 파일에 있는 path 경로를 수정 devEnv파일에 google API json 추가

## 구현 사항
- googleApiService 빈의 의존성 주입 과정에서 실패하여 yml 파일에 있는 path 경로를 수정 devEnv파일에 google API json 추가