### PR TITLE
[feat] 다솜소식 API 구현

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
+++ b/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
@@ -11,11 +11,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
 import java.util.List;
 
 @Tag(name = "NEWS API", description = "다솜소식 API")
 @RestController
-@RequestMapping("/news")
+@RequestMapping("/api/news")
 public class NewsController {
 
     private final NewsService newsService;
@@ -42,7 +44,7 @@ public class NewsController {
     })
 
     @PostMapping
-    public ResponseEntity<NewsResponseDto> createNews(@RequestBody NewsRequestDto requestDto) {
+    public ResponseEntity<NewsResponseDto> createNews(@Valid @RequestBody NewsRequestDto requestDto) {
         NewsResponseDto responseDto = newsService.createNews(requestDto);
         return ResponseEntity.status(201).body(responseDto);
     }

--- a/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
+++ b/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
@@ -1,0 +1,50 @@
+package dmu.dasom.api.domain.news.controller;
+
+import dmu.dasom.api.domain.news.dto.NewsRequestDto;
+import dmu.dasom.api.domain.news.dto.NewsResponseDto;
+import dmu.dasom.api.domain.news.service.NewsService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@Tag(name = "NEWS API", description = "다솜소식 API")
+@RestController
+@RequestMapping("/news")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    public NewsController(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @Operation(summary = "소식 조회", description = "리스트로 조회")
+    @ApiResponse(responseCode = "200", description = "정상 응답",
+            content = @Content(mediaType = "application/json"))
+    @GetMapping
+    public ResponseEntity<List<NewsResponseDto>> getAllNews() {
+        List<NewsResponseDto> newsList = newsService.getAllNews();
+        return ResponseEntity.ok(newsList);
+    }
+
+    @Operation(summary = "소식 등록", description = "새로운 소식을 등록")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "생성 완료"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 데이터",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = "{ \"errorCode\": \"E003\", \"errorMessage\": \"유효하지 않은 입력입니다.\" }")))
+    })
+
+    @PostMapping
+    public ResponseEntity<NewsResponseDto> createNews(@RequestBody NewsRequestDto requestDto) {
+        NewsResponseDto responseDto = newsService.createNews(requestDto);
+        return ResponseEntity.status(201).body(responseDto);
+    }
+
+}

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
@@ -1,24 +1,24 @@
 package dmu.dasom.api.domain.news.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
-@Schema(description = "뉴스 요청 DTO")
+@Schema(name = "NewsRequestDto", description = "뉴스 생성 요청 DTO")
 public class NewsRequestDto {
 
+    @NotBlank
+    @Size(max = 100)
     @Schema(description = "뉴스 제목", example = "새로운 뉴스 제목")
-    @NotNull
     private String title;
 
+    @NotBlank
     @Schema(description = "뉴스 내용", example = "새로운 뉴스 내용")
-    @NotNull
     private String content;
 
-    @Schema(description = "뉴스 이미지 URL", example = "http://example.com/new-image.jpg")
+    @Size(max = 255)
+    @Schema(description = "뉴스 이미지 URL", example = "http://example.com/image.jpg", nullable = true)
     private String imageUrl;
-
 }

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
@@ -3,9 +3,13 @@ package dmu.dasom.api.domain.news.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Schema(name = "NewsRequestDto", description = "뉴스 생성 요청 DTO")
 public class NewsRequestDto {
 

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsRequestDto.java
@@ -1,0 +1,24 @@
+package dmu.dasom.api.domain.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "뉴스 요청 DTO")
+public class NewsRequestDto {
+
+    @Schema(description = "뉴스 제목", example = "새로운 뉴스 제목")
+    @NotNull
+    private String title;
+
+    @Schema(description = "뉴스 내용", example = "새로운 뉴스 내용")
+    @NotNull
+    private String content;
+
+    @Schema(description = "뉴스 이미지 URL", example = "http://example.com/new-image.jpg")
+    private String imageUrl;
+
+}

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
@@ -10,19 +10,19 @@ import java.time.LocalDateTime;
 public class NewsResponseDto {
 
     @Schema(description = "소식 ID", example = "1")
-    private final Long id;
+    private Long id;
 
     @Schema(description = "뉴스 제목", example = "제목")
-    private final String title;
+    private String title;
 
     @Schema(description = "뉴스 내용", example = "내용")
-    private final String content;
+    private String content;
 
     @Schema(description = "작성일", example = "2025-02-14T12:00:00")
-    private final LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
     @Schema(description = "뉴스 이미지 URL", example = "http://example.com/image.jpg", nullable = true)
-    private final String imageUrl;
+    private String imageUrl;
 
     public NewsResponseDto(Long id, String title, String content, LocalDateTime createdAt, String imageUrl) {
         this.id = id;

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
@@ -6,23 +6,23 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-@Schema(description = "응답 DTO")
+@Schema(name = "NewsResponseDto", description = "뉴스 응답 DTO")
 public class NewsResponseDto {
 
     @Schema(description = "소식 ID", example = "1")
-    private Long id;
+    private final Long id;
 
-    @Schema(description = "제목", example = "제목")
-    private String title;
+    @Schema(description = "뉴스 제목", example = "제목")
+    private final String title;
 
-    @Schema(description = "내용", example = "내용")
-    private String content;
+    @Schema(description = "뉴스 내용", example = "내용")
+    private final String content;
 
     @Schema(description = "작성일", example = "2025-02-14T12:00:00")
-    private LocalDateTime createdAt;
+    private final LocalDateTime createdAt;
 
-    @Schema(description = "이미지 URL", example = "http://example.com/image.jpg")
-    private String imageUrl;
+    @Schema(description = "뉴스 이미지 URL", example = "http://example.com/image.jpg", nullable = true)
+    private final String imageUrl;
 
     public NewsResponseDto(Long id, String title, String content, LocalDateTime createdAt, String imageUrl) {
         this.id = id;

--- a/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/news/dto/NewsResponseDto.java
@@ -1,0 +1,34 @@
+package dmu.dasom.api.domain.news.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "응답 DTO")
+public class NewsResponseDto {
+
+    @Schema(description = "소식 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "제목", example = "제목")
+    private String title;
+
+    @Schema(description = "내용", example = "내용")
+    private String content;
+
+    @Schema(description = "작성일", example = "2025-02-14T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "이미지 URL", example = "http://example.com/image.jpg")
+    private String imageUrl;
+
+    public NewsResponseDto(Long id, String title, String content, LocalDateTime createdAt, String imageUrl) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
+++ b/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
@@ -36,12 +36,12 @@ public class NewsEntity extends BaseEntity {
     @Column(length = 255)
     private String imageUrl;
 
-    // 🔹 뉴스 상태 업데이트
+    // 뉴스 상태 업데이트
     public void updateStatus(Status status) {
         super.updateStatus(status);
     }
 
-    // 🔹 NewsEntity → NewsResponseDto 변환
+    // NewsEntity → NewsResponseDto 변환
     public NewsResponseDto toResponseDto() {
         return new NewsResponseDto(id, title, content, getCreatedAt(), imageUrl);
     }

--- a/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
+++ b/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
-@Setter
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
+++ b/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
@@ -1,40 +1,48 @@
 package dmu.dasom.api.domain.news.entity;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
+import dmu.dasom.api.domain.common.BaseEntity;
+import dmu.dasom.api.domain.common.Status;
+import dmu.dasom.api.domain.news.dto.NewsResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.time.LocalDateTime;
+import lombok.*;
 
 @Getter
 @Setter
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Schema(description = "뉴스 엔티티")
-public class NewsEntity {
+public class NewsEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Schema(description = "뉴스 ID", example = "1")
     private Long id;
 
-    @Schema(description = "뉴스 제목", example = "뉴스 예제 제목")
     @NotNull
+    @Schema(description = "뉴스 제목", example = "뉴스 예제 제목")
+    @Column(nullable = false, length = 100)
     private String title;
 
-    @Schema(description = "뉴스 내용", example = "뉴스 예제 내용")
     @NotNull
-    @Column(columnDefinition = "TEXT")
+    @Schema(description = "뉴스 내용", example = "뉴스 예제 내용")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Schema(description = "뉴스 작성일", example = "2025-02-14T12:00:00")
-    private LocalDateTime createdAt;
-
     @Schema(description = "뉴스 이미지 URL", example = "http://example.com/image.jpg")
+    @Column(length = 255)
     private String imageUrl;
+
+    // 🔹 뉴스 상태 업데이트
+    public void updateStatus(Status status) {
+        super.updateStatus(status);
+    }
+
+    // 🔹 NewsEntity → NewsResponseDto 변환
+    public NewsResponseDto toResponseDto() {
+        return new NewsResponseDto(id, title, content, getCreatedAt(), imageUrl);
+    }
 }

--- a/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
+++ b/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
@@ -5,7 +5,9 @@ import dmu.dasom.api.domain.common.Status;
 import dmu.dasom.api.domain.news.dto.NewsResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -44,4 +46,25 @@ public class NewsEntity extends BaseEntity {
     public NewsResponseDto toResponseDto() {
         return new NewsResponseDto(id, title, content, getCreatedAt(), imageUrl);
     }
+
+    //수정기능
+    public void update(String title, String content, String imageUrl) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("제목은 필수입니다");
+        }
+        if (title.length() > 100) {
+            throw new IllegalArgumentException("제목은 100자까지");
+        }
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("내용은 필수입니다");
+        }
+        if (imageUrl != null && imageUrl.length() > 255) {
+            throw new IllegalArgumentException("이미지 URL은 255자까지");
+        }
+
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+    }
+
 }

--- a/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
+++ b/src/main/java/dmu/dasom/api/domain/news/entity/NewsEntity.java
@@ -1,0 +1,40 @@
+package dmu.dasom.api.domain.news.entity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Schema(description = "뉴스 엔티티")
+public class NewsEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "뉴스 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "뉴스 제목", example = "뉴스 예제 제목")
+    @NotNull
+    private String title;
+
+    @Schema(description = "뉴스 내용", example = "뉴스 예제 내용")
+    @NotNull
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Schema(description = "뉴스 작성일", example = "2025-02-14T12:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "뉴스 이미지 URL", example = "http://example.com/image.jpg")
+    private String imageUrl;
+}

--- a/src/main/java/dmu/dasom/api/domain/news/repository/NewsRepository.java
+++ b/src/main/java/dmu/dasom/api/domain/news/repository/NewsRepository.java
@@ -1,0 +1,9 @@
+package dmu.dasom.api.domain.news.repository;
+
+import dmu.dasom.api.domain.news.entity.NewsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsRepository extends JpaRepository<NewsEntity, Long> {
+}

--- a/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
+++ b/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
@@ -42,4 +42,5 @@ public class NewsService {
         NewsEntity savedNews = newsRepository.save(news);
         return savedNews.toResponseDto();
     }
+
 }

--- a/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
+++ b/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
@@ -5,6 +5,7 @@ import dmu.dasom.api.domain.news.dto.NewsResponseDto;
 import dmu.dasom.api.domain.news.entity.NewsEntity;
 import dmu.dasom.api.domain.news.repository.NewsRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,4 +44,22 @@ public class NewsService {
         return savedNews.toResponseDto();
     }
 
+    // 수정
+    @Transactional
+    public NewsResponseDto updateNews(Long id, NewsRequestDto requestDto) {
+        NewsEntity news = newsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 뉴스가 존재하지 않습니다. ID: " + id));
+
+        news.update(requestDto.getTitle(), requestDto.getContent(), requestDto.getImageUrl());
+        return news.toResponseDto();
+    }
+
+    // 삭제
+    @Transactional
+    public void deleteNews(Long id) {
+        NewsEntity news = newsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 뉴스가 존재하지 않습니다. ID: " + id));
+
+        newsRepository.delete(news);
+    }
 }

--- a/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
+++ b/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
@@ -5,7 +5,6 @@ import dmu.dasom.api.domain.news.dto.NewsResponseDto;
 import dmu.dasom.api.domain.news.entity.NewsEntity;
 import dmu.dasom.api.domain.news.repository.NewsRepository;
 import org.springframework.stereotype.Service;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,21 +17,22 @@ public class NewsService {
         this.newsRepository = newsRepository;
     }
 
+    // 🔹 전체 조회
     public List<NewsResponseDto> getAllNews() {
         return newsRepository.findAll().stream()
-                .map(news -> new NewsResponseDto(news.getId(), news.getTitle(), news.getContent(), news.getCreatedAt(), news.getImageUrl()))
+                .map(NewsEntity::toResponseDto)
                 .collect(Collectors.toList());
     }
 
+    // 🔹 생성
     public NewsResponseDto createNews(NewsRequestDto requestDto) {
-        NewsEntity news = new NewsEntity();
-        news.setTitle(requestDto.getTitle());
-        news.setContent(requestDto.getContent());
-        news.setImageUrl(requestDto.getImageUrl());
-        news.setCreatedAt(LocalDateTime.now());
+        NewsEntity news = NewsEntity.builder()
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .imageUrl(requestDto.getImageUrl())
+                .build();
 
         NewsEntity savedNews = newsRepository.save(news);
-        return new NewsResponseDto(savedNews.getId(), savedNews.getTitle(), savedNews.getContent(), savedNews.getCreatedAt(), savedNews.getImageUrl());
+        return savedNews.toResponseDto();
     }
-
 }

--- a/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
+++ b/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
@@ -17,14 +17,21 @@ public class NewsService {
         this.newsRepository = newsRepository;
     }
 
-    // 🔹 전체 조회
+    // 전체 조회
     public List<NewsResponseDto> getAllNews() {
         return newsRepository.findAll().stream()
                 .map(NewsEntity::toResponseDto)
                 .collect(Collectors.toList());
     }
 
-    // 🔹 생성
+    // 개별 조회
+    public NewsResponseDto getNewsById(Long id) {
+        return newsRepository.findById(id)
+                .map(NewsEntity::toResponseDto)
+                .orElseThrow(() -> new IllegalArgumentException("해당 뉴스가 존재하지 않습니다. ID: " + id));
+    }
+
+    // 생성
     public NewsResponseDto createNews(NewsRequestDto requestDto) {
         NewsEntity news = NewsEntity.builder()
                 .title(requestDto.getTitle())

--- a/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
+++ b/src/main/java/dmu/dasom/api/domain/news/service/NewsService.java
@@ -1,0 +1,38 @@
+package dmu.dasom.api.domain.news.service;
+
+import dmu.dasom.api.domain.news.dto.NewsRequestDto;
+import dmu.dasom.api.domain.news.dto.NewsResponseDto;
+import dmu.dasom.api.domain.news.entity.NewsEntity;
+import dmu.dasom.api.domain.news.repository.NewsRepository;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+
+    public NewsService(NewsRepository newsRepository) {
+        this.newsRepository = newsRepository;
+    }
+
+    public List<NewsResponseDto> getAllNews() {
+        return newsRepository.findAll().stream()
+                .map(news -> new NewsResponseDto(news.getId(), news.getTitle(), news.getContent(), news.getCreatedAt(), news.getImageUrl()))
+                .collect(Collectors.toList());
+    }
+
+    public NewsResponseDto createNews(NewsRequestDto requestDto) {
+        NewsEntity news = new NewsEntity();
+        news.setTitle(requestDto.getTitle());
+        news.setContent(requestDto.getContent());
+        news.setImageUrl(requestDto.getImageUrl());
+        news.setCreatedAt(LocalDateTime.now());
+
+        NewsEntity savedNews = newsRepository.save(news);
+        return new NewsResponseDto(savedNews.getId(), savedNews.getTitle(), savedNews.getContent(), savedNews.getCreatedAt(), savedNews.getImageUrl());
+    }
+
+}

--- a/src/test/java/dmu/dasom/api/domain/news/NewsServiceTest.java
+++ b/src/test/java/dmu/dasom/api/domain/news/NewsServiceTest.java
@@ -1,0 +1,114 @@
+package dmu.dasom.api.domain.news;
+
+import dmu.dasom.api.domain.news.dto.NewsRequestDto;
+import dmu.dasom.api.domain.news.dto.NewsResponseDto;
+import dmu.dasom.api.domain.news.entity.NewsEntity;
+import dmu.dasom.api.domain.news.repository.NewsRepository;
+import dmu.dasom.api.domain.news.service.NewsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NewsServiceTest {
+
+    @Mock
+    private NewsRepository newsRepository;
+
+    @InjectMocks
+    private NewsService newsService;
+
+    @Test
+    @DisplayName("뉴스 전체 조회 테스트")
+    void getAllNews() {
+        // Given
+        NewsEntity news1 = NewsEntity.builder().id(1L).title("뉴스1").content("내용1").imageUrl("url1").build();
+        NewsEntity news2 = NewsEntity.builder().id(2L).title("뉴스2").content("내용2").imageUrl("url2").build();
+
+        when(newsRepository.findAll()).thenReturn(List.of(news1, news2));
+
+        // When
+        List<NewsResponseDto> newsList = newsService.getAllNews();
+
+        // Then
+        assertThat(newsList).hasSize(2);
+        assertThat(newsList.get(0).getTitle()).isEqualTo("뉴스1");
+        verify(newsRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("뉴스 개별 조회 - 성공")
+    void getNewsById_Success() {
+        // Given
+        Long id = 1L;
+        NewsEntity news = NewsEntity.builder().id(id).title("뉴스1").content("내용1").imageUrl("url1").build();
+
+        when(newsRepository.findById(id)).thenReturn(Optional.of(news));
+
+        // When
+        NewsResponseDto responseDto = newsService.getNewsById(id);
+
+        // Then
+        assertThat(responseDto.getId()).isEqualTo(id);
+        assertThat(responseDto.getTitle()).isEqualTo("뉴스1");
+        verify(newsRepository, times(1)).findById(id);
+    }
+
+    @Test
+    @DisplayName("뉴스 개별 조회 - 실패 (존재하지 않는 ID)")
+    void getNewsById_NotFound() {
+        // Given
+        Long id = 999L;
+
+        when(newsRepository.findById(id)).thenReturn(Optional.empty());
+
+        // When & Then
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> newsService.getNewsById(id));
+        assertThat(exception.getMessage()).isEqualTo("해당 뉴스가 존재하지 않습니다. ID: " + id);
+        verify(newsRepository, times(1)).findById(id);
+    }
+
+    @Test
+    @DisplayName("뉴스 생성 테스트")
+    void createNews() {
+        // Given
+        NewsRequestDto requestDto = new NewsRequestDto("새 뉴스", "새 내용", "새 이미지");
+
+        NewsEntity news = NewsEntity.builder()
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .imageUrl(requestDto.getImageUrl())
+                .build();
+
+        NewsEntity savedNews = NewsEntity.builder()
+                .id(1L)
+                .title(news.getTitle())
+                .content(news.getContent())
+                .imageUrl(news.getImageUrl())
+                .build();
+
+        when(newsRepository.save(any(NewsEntity.class))).thenReturn(savedNews);
+
+        // When
+        NewsResponseDto responseDto = newsService.createNews(requestDto);
+
+        // Then
+        assertThat(responseDto.getId()).isEqualTo(1L); // 저장된 뉴스의 ID 할당확인
+        assertThat(responseDto.getTitle()).isEqualTo("새 뉴스");
+        assertThat(responseDto.getContent()).isEqualTo("새 내용");
+        assertThat(responseDto.getImageUrl()).isEqualTo("새 이미지");
+
+        verify(newsRepository, times(1)).save(any(NewsEntity.class)); // save() 호출 검증
+    }
+
+}


### PR DESCRIPTION
# [feat] 다솜소식 API 구현

## Issue
- #33 

## 변경 내용
- 다솜소식 조회, 등록 API 구현

## 구현 사항
- NewsRequest, ResponseDto
- Contoller
- Service
- Entity
- Repository

## 테스트 (필요 시)
- 저,,, 무슨 문제인진 모르겠지만 redis가 제대로 설치가 안돼서 postman에서 못돌려봤습니다..... Windows에서 지원을 중단하였다고 하는데 해결방법 아시는 분 헬프 부탁드립니다.