### PR TITLE
[feat] 토큰 응답 시 사용자 권한 응답 추가

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/member/controller/MemberController.java
+++ b/src/main/java/dmu/dasom/api/domain/member/controller/MemberController.java
@@ -64,6 +64,7 @@ public class MemberController {
         final HttpHeaders headers = new HttpHeaders();
         headers.add("Access-Token", tokenBox.getAccessToken());
         headers.add("Refresh-Token", tokenBox.getRefreshToken());
+        headers.add("Authority", tokenBox.getAuthority());
 
         return ResponseEntity.ok().headers(headers).build();
     }

--- a/src/main/java/dmu/dasom/api/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/dmu/dasom/api/domain/member/service/MemberServiceImpl.java
@@ -9,9 +9,13 @@ import dmu.dasom.api.global.auth.dto.TokenBox;
 import dmu.dasom.api.global.auth.jwt.JwtUtil;
 import dmu.dasom.api.global.auth.userdetails.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 @RequiredArgsConstructor
 @Service
@@ -49,7 +53,13 @@ public class MemberServiceImpl implements MemberService {
     // 토큰 갱신
     @Override
     public TokenBox tokenRotation(final UserDetailsImpl userDetails) {
-        return jwtUtil.tokenRotation(userDetails);
+        final Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+        final Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        final GrantedAuthority auth = iterator.next();
+
+        final String authority = auth.getAuthority();
+
+        return jwtUtil.tokenRotation(userDetails.getUsername(), authority);
     }
 
 }

--- a/src/main/java/dmu/dasom/api/global/auth/dto/TokenBox.java
+++ b/src/main/java/dmu/dasom/api/global/auth/dto/TokenBox.java
@@ -19,4 +19,8 @@ public class TokenBox {
     @NotNull
     private String refreshToken;
 
+    @Schema(description = "권한")
+    @NotNull
+    private String authority;
+
 }

--- a/src/main/java/dmu/dasom/api/global/auth/filter/CustomAuthenticationFilter.java
+++ b/src/main/java/dmu/dasom/api/global/auth/filter/CustomAuthenticationFilter.java
@@ -17,9 +17,12 @@ import org.springframework.security.authentication.InternalAuthenticationService
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 
 @RequiredArgsConstructor
 public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
@@ -47,12 +50,19 @@ public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFi
         // 기존 토큰 만료 처리
         jwtUtil.blacklistTokens(authResult.getName());
 
+        final Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+        final Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        final GrantedAuthority auth = iterator.next();
+
+        final String authority = auth.getAuthority();
+
         // 토큰 생성
-        final TokenBox tokenBox = jwtUtil.generateTokenBox(authResult.getName());
+        final TokenBox tokenBox = jwtUtil.generateTokenBox(authResult.getName(), authority);
 
         response.setStatus(HttpStatus.OK.value());
         response.setHeader("Access-Token", tokenBox.getAccessToken());
         response.setHeader("Refresh-Token", tokenBox.getRefreshToken());
+        response.setHeader("Authority", tokenBox.getAuthority());
     }
 
     @Override

--- a/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/dmu/dasom/api/global/auth/jwt/JwtUtil.java
@@ -38,10 +38,11 @@ public class JwtUtil {
     }
 
     // Access, Refresh 토큰 생성
-    public TokenBox generateTokenBox(final String email) {
+    public TokenBox generateTokenBox(final String email, final String authority) {
         final TokenBox tokenBox = TokenBox.builder()
                 .accessToken(generateToken(email, accessTokenExpiration))
                 .refreshToken(generateToken(email, refreshTokenExpiration))
+                .authority(authority)
                 .build();
 
         saveTokens(tokenBox, email);
@@ -132,9 +133,9 @@ public class JwtUtil {
     }
 
     // Access, Refresh 토큰 갱신
-    public TokenBox tokenRotation(final UserDetailsImpl userDetails) {
-        blacklistTokens(userDetails.getUsername());
-        return generateTokenBox(userDetails.getUsername());
+    public TokenBox tokenRotation(final String email, final String authority) {
+        blacklistTokens(email);
+        return generateTokenBox(email, authority);
     }
 
 }


### PR DESCRIPTION
# [feat] 토큰 응답 시 사용자 권한 응답 추가

# Issue
- #32 

## 변경 내용
- 클라이언트 자체적으로 접근 권한을 처리하기 위해 토큰 응답 시 사용자 권한도 같이 응답

## 구현 사항
- 응답 헤더로 사용자 권한 응답
- 쿠키로 응답시켜 위조를 방지하는 방식으로 추후 개선 필요