### PR TITLE
[feat] 다솜소식 수정 삭제 명세서 추가

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
+++ b/src/main/java/dmu/dasom/api/domain/news/controller/NewsController.java
@@ -26,6 +26,7 @@ public class NewsController {
         this.newsService = newsService;
     }
 
+    // 전체 조회
     @Operation(summary = "소식 조회", description = "리스트로 조회")
     @ApiResponse(responseCode = "200", description = "정상 응답",
             content = @Content(mediaType = "application/json"))
@@ -35,6 +36,19 @@ public class NewsController {
         return ResponseEntity.ok(newsList);
     }
 
+    // 개별 조회
+    @Operation(summary = "소식 상세 조회", description = "ID로 특정 소식을 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "소식을 찾을 수 없음")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<NewsResponseDto> getNewsById(@PathVariable Long id) {
+        NewsResponseDto responseDto = newsService.getNewsById(id);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 생성
     @Operation(summary = "소식 등록", description = "새로운 소식을 등록")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "생성 완료"),
@@ -42,11 +56,34 @@ public class NewsController {
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = "{ \"errorCode\": \"E003\", \"errorMessage\": \"유효하지 않은 입력입니다.\" }")))
     })
-
     @PostMapping
     public ResponseEntity<NewsResponseDto> createNews(@Valid @RequestBody NewsRequestDto requestDto) {
         NewsResponseDto responseDto = newsService.createNews(requestDto);
         return ResponseEntity.status(201).body(responseDto);
     }
 
+    // 수정
+    @Operation(summary = "소식 수정", description = "ID로 특정 소식을 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "404", description = "소식을 찾을 수 없음")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<NewsResponseDto> updateNews(@PathVariable Long id, @Valid @RequestBody NewsRequestDto requestDto) {
+        NewsResponseDto updatedNews = newsService.updateNews(id, requestDto);
+        return ResponseEntity.ok(updatedNews);
+    }
+
+    // 삭제
+    @Operation(summary = "소식 삭제", description = "ID로 특정 소식을 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "소식을 찾을 수 없음")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNews(@PathVariable Long id) {
+        newsService.deleteNews(id);
+        return ResponseEntity.noContent().build();
+    }
+    
 }


### PR DESCRIPTION
# [feat] 다솜소식 수정 삭제 명세서 추가

## Issue
- #43 

## 변경 내용
- NewsController에 수정, 삭제가 기술이 안되어 있어 추가했습니다.

## 구현 사항
- 수정 -> PutMapping
- 삭제 -> DeleteMapping 사용해서 구현했습니다.
- 조회도 전체, 개별로 나눠봤습니다.