### PR TITLE
[feat] 합격 조회 API 구현

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/dmu/dasom/api/domain/applicant/service/ApplicantService.java
@@ -19,4 +19,6 @@ public interface ApplicantService {
 
     void sendEmailsToApplicants(MailType mailType);
 
+    ApplicantDetailsResponseDto getApplicantByStudentNo(final String studentNo);
+
 }

--- a/src/main/java/dmu/dasom/api/domain/applicant/service/ApplicantServiceImpl.java
+++ b/src/main/java/dmu/dasom/api/domain/applicant/service/ApplicantServiceImpl.java
@@ -110,6 +110,13 @@ public class ApplicantServiceImpl implements ApplicantService {
         }
     }
 
+    // 학번으로 지원자 조회
+    @Override
+    public ApplicantDetailsResponseDto getApplicantByStudentNo(final String studentNo) {
+        return findByStudentNo(studentNo)
+            .map(Applicant::toApplicantDetailsResponse)
+            .orElseThrow(() -> new CustomException(ErrorCode.ARGUMENT_NOT_VALID));
+    }
 
     // Repository에서 ID로 지원자 조회
     private Applicant findById(final Long id) {

--- a/src/main/java/dmu/dasom/api/domain/common/exception/ErrorCode.java
+++ b/src/main/java/dmu/dasom/api/domain/common/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     SEND_EMAIL_FAIL(400, "C014", "이메일 전송에 실패하였습니다."),
     MAIL_TYPE_NOT_VALID(400, "C015", "메일 타입이 올바르지 않습니다."),
     INVALID_DATETIME_FORMAT(400, "C016", "날짜 형식이 올바르지 않습니다."),
-    INVALID_TIME_FORMAT(400, "C017", "시간 형식이 올바르지 않습니다.")
+    INVALID_TIME_FORMAT(400, "C017", "시간 형식이 올바르지 않습니다."),
+    INVALID_INQUIRY_PERIOD(400, "C018", "조회 기간이 아닙니다.")
     ;
 
     private final int status;

--- a/src/main/java/dmu/dasom/api/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/dmu/dasom/api/domain/recruit/controller/RecruitController.java
@@ -3,6 +3,8 @@ package dmu.dasom.api.domain.recruit.controller;
 import dmu.dasom.api.domain.applicant.dto.ApplicantCreateRequestDto;
 import dmu.dasom.api.domain.applicant.service.ApplicantService;
 import dmu.dasom.api.domain.common.exception.ErrorResponse;
+import dmu.dasom.api.domain.recruit.dto.ResultCheckRequestDto;
+import dmu.dasom.api.domain.recruit.dto.ResultCheckResponseDto;
 import dmu.dasom.api.domain.recruit.dto.RecruitConfigResponseDto;
 import dmu.dasom.api.domain.recruit.service.RecruitService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,19 +31,22 @@ public class RecruitController {
     // 지원하기
     @Operation(summary = "부원 지원하기")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "지원 성공"),
-            @ApiResponse(responseCode = "400", description = "실패 케이스",
-                content = @Content(
-                        mediaType = "application/json",
-                        schema = @Schema(implementation = ErrorResponse.class),
-                        examples = {
-                            @ExampleObject(
-                                name = "학번 중복",
-                                value = "{ \"code\": \"C013\", \"message\": \"이미 등록된 학번입니다.\" }")}))})
+        @ApiResponse(responseCode = "200", description = "지원 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "학번 중복",
+                        value = "{ \"code\": \"C013\", \"message\": \"이미 등록된 학번입니다.\" }")
+                }))
+    })
     @PostMapping("/apply")
     public ResponseEntity<Void> apply(@Valid @RequestBody final ApplicantCreateRequestDto request) {
         applicantService.apply(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+            .build();
     }
 
     // 모집 일정 조회
@@ -50,6 +55,25 @@ public class RecruitController {
     @GetMapping
     public ResponseEntity<List<RecruitConfigResponseDto>> getRecruitSchedule() {
         return ResponseEntity.ok(recruitService.getRecruitSchedule());
+    }
+
+    // 합격 결과 확인
+    @Operation(summary = "합격 결과 확인")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "합격 결과 확인 성공"),
+        @ApiResponse(responseCode = "400", description = "실패 케이스",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(
+                        name = "학번 조회 실패 혹은 전화번호 뒷자리 일치하지 않음",
+                        value = "{ \"code\": \"C007\", \"message\": \"요청한 값이 올바르지 않습니다.\" }")
+                }))
+    })
+    @GetMapping("/result")
+    public ResponseEntity<ResultCheckResponseDto> checkResult(@ModelAttribute final ResultCheckRequestDto request) {
+        return ResponseEntity.ok(recruitService.checkResult(request));
     }
 
 }

--- a/src/main/java/dmu/dasom/api/domain/recruit/dto/ResultCheckRequestDto.java
+++ b/src/main/java/dmu/dasom/api/domain/recruit/dto/ResultCheckRequestDto.java
@@ -1,0 +1,35 @@
+package dmu.dasom.api.domain.recruit.dto;
+
+import dmu.dasom.api.domain.recruit.enums.ResultCheckType;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ParameterObject
+@Schema(name = "ResultCheckRequestDto", description = "지원 결과 확인 요청 DTO")
+public class ResultCheckRequestDto {
+
+    @NotNull
+    @Parameter(description = "지원 결과 조회 타입")
+    @Schema(example = "DOCUMENT_PASS")
+    private ResultCheckType type;
+
+    @NotNull
+    @Parameter(description = "학번")
+    @Schema(example = "20210000")
+    private String studentNo;
+
+    @NotNull
+    @Parameter(description = "전화번호 뒷자리")
+    @Schema(example = "6789")
+    private String contactLastDigit;
+
+}

--- a/src/main/java/dmu/dasom/api/domain/recruit/dto/ResultCheckResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/recruit/dto/ResultCheckResponseDto.java
@@ -1,0 +1,33 @@
+package dmu.dasom.api.domain.recruit.dto;
+
+import dmu.dasom.api.domain.recruit.enums.ResultCheckType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(name = "ResultCheckResponseDto", description = "지원 결과 확인 응답 DTO")
+public class ResultCheckResponseDto {
+
+    @NotNull
+    @Schema(description = "지원 결과 확인 타입", example = "DOCUMENT_PASS")
+    ResultCheckType type;
+
+    @NotNull
+    @Schema(description = "학번", example = "20210000")
+    @Size(min = 8, max = 8)
+    String studentNo;
+
+    @NotNull
+    @Schema(description = "이름", example = "홍길동")
+    @Size(max = 16)
+    String name;
+
+    @NotNull
+    @Schema(description = "결과", example = "true")
+    Boolean isPassed;
+
+}

--- a/src/main/java/dmu/dasom/api/domain/recruit/enums/ResultCheckType.java
+++ b/src/main/java/dmu/dasom/api/domain/recruit/enums/ResultCheckType.java
@@ -1,0 +1,6 @@
+package dmu.dasom.api.domain.recruit.enums;
+
+public enum ResultCheckType {
+    DOCUMENT_PASS,
+    INTERVIEW_PASS
+}

--- a/src/main/java/dmu/dasom/api/domain/recruit/service/RecruitService.java
+++ b/src/main/java/dmu/dasom/api/domain/recruit/service/RecruitService.java
@@ -1,5 +1,7 @@
 package dmu.dasom.api.domain.recruit.service;
 
+import dmu.dasom.api.domain.recruit.dto.ResultCheckRequestDto;
+import dmu.dasom.api.domain.recruit.dto.ResultCheckResponseDto;
 import dmu.dasom.api.domain.recruit.dto.RecruitConfigResponseDto;
 import dmu.dasom.api.domain.recruit.dto.RecruitScheduleModifyRequestDto;
 
@@ -10,5 +12,7 @@ public interface RecruitService {
     List<RecruitConfigResponseDto> getRecruitSchedule();
 
     void modifyRecruitSchedule(final RecruitScheduleModifyRequestDto requestDto);
+
+    ResultCheckResponseDto checkResult(final ResultCheckRequestDto request);
 
 }

--- a/src/test/java/dmu/dasom/api/domain/applicant/ApplicantServiceTest.java
+++ b/src/test/java/dmu/dasom/api/domain/applicant/ApplicantServiceTest.java
@@ -1,6 +1,7 @@
 package dmu.dasom.api.domain.applicant;
 
 import dmu.dasom.api.domain.applicant.dto.ApplicantCreateRequestDto;
+import dmu.dasom.api.domain.applicant.dto.ApplicantDetailsResponseDto;
 import dmu.dasom.api.domain.applicant.dto.ApplicantResponseDto;
 import dmu.dasom.api.domain.applicant.entity.Applicant;
 import dmu.dasom.api.domain.applicant.enums.ApplicantStatus;
@@ -176,4 +177,39 @@ class ApplicantServiceTest {
         verify(emailService).sendEmail("passed@example.com", "합격자", mailType);
         verify(emailService).sendEmail("failed@example.com", "불합격자", mailType);
     }
+
+    @Test
+    @DisplayName("학번으로 지원자 조회 - 성공")
+    void getApplicantByStudentNo_success() {
+        // given
+        String studentNo = "20210000";
+        Applicant applicant = mock(Applicant.class);
+        when(applicantRepository.findByStudentNo(studentNo)).thenReturn(Optional.of(applicant));
+        when(applicant.toApplicantDetailsResponse()).thenReturn(mock(ApplicantDetailsResponseDto.class));
+
+        // when
+        ApplicantDetailsResponseDto applicantByStudentNo = applicantService.getApplicantByStudentNo(studentNo);
+
+        // then
+        assertNotNull(applicantByStudentNo);
+        verify(applicantRepository).findByStudentNo(studentNo);
+    }
+
+    @Test
+    @DisplayName("학번으로 지원자 조회 - 실패 (결과 없음)")
+    void getApplicantByStudentNo_fail() {
+        // given
+        String studentNo = "20210000";
+        when(applicantRepository.findByStudentNo(studentNo)).thenReturn(Optional.empty());
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            applicantService.getApplicantByStudentNo(studentNo);
+        });
+
+        // then
+        verify(applicantRepository).findByStudentNo(studentNo);
+        assertEquals(ErrorCode.ARGUMENT_NOT_VALID, exception.getErrorCode());
+    }
+
 }

--- a/src/test/java/dmu/dasom/api/domain/recruit/RecruitServiceTest.java
+++ b/src/test/java/dmu/dasom/api/domain/recruit/RecruitServiceTest.java
@@ -1,11 +1,17 @@
 package dmu.dasom.api.domain.recruit;
 
+import dmu.dasom.api.domain.applicant.dto.ApplicantDetailsResponseDto;
+import dmu.dasom.api.domain.applicant.enums.ApplicantStatus;
+import dmu.dasom.api.domain.applicant.service.ApplicantServiceImpl;
 import dmu.dasom.api.domain.common.exception.CustomException;
 import dmu.dasom.api.domain.common.exception.ErrorCode;
+import dmu.dasom.api.domain.recruit.dto.ResultCheckRequestDto;
+import dmu.dasom.api.domain.recruit.dto.ResultCheckResponseDto;
 import dmu.dasom.api.domain.recruit.dto.RecruitConfigResponseDto;
 import dmu.dasom.api.domain.recruit.dto.RecruitScheduleModifyRequestDto;
 import dmu.dasom.api.domain.recruit.entity.Recruit;
 import dmu.dasom.api.domain.recruit.enums.ConfigKey;
+import dmu.dasom.api.domain.recruit.enums.ResultCheckType;
 import dmu.dasom.api.domain.recruit.repository.RecruitRepository;
 import dmu.dasom.api.domain.recruit.service.RecruitServiceImpl;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +35,9 @@ class RecruitServiceTest {
 
     @Mock
     private RecruitRepository recruitRepository;
+
+    @Mock
+    private ApplicantServiceImpl applicantService;
 
     @InjectMocks
     private RecruitServiceImpl recruitService;
@@ -83,4 +93,90 @@ class RecruitServiceTest {
         // then
         assertEquals(ErrorCode.INVALID_TIME_FORMAT, exception.getErrorCode());
     }
+
+    @Test
+    @DisplayName("합격 결과 확인 - 성공")
+    void checkResult_success() {
+        // given
+        Recruit recruit = mock(Recruit.class);
+        when(recruitRepository.findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT)).thenReturn(Optional.of(recruit));
+        String pastDateTime = LocalDateTime.now().minusHours(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        when(recruit.getValue()).thenReturn(pastDateTime);
+
+        ResultCheckRequestDto request = mock(ResultCheckRequestDto.class);
+        when(request.getType()).thenReturn(ResultCheckType.DOCUMENT_PASS);
+        when(request.getStudentNo()).thenReturn("20210000");
+        when(request.getContactLastDigit()).thenReturn("1234");
+
+        ApplicantDetailsResponseDto applicant = mock(ApplicantDetailsResponseDto.class);
+        when(applicant.getContact()).thenReturn("010-5678-1234");
+        when(applicant.getStatus()).thenReturn(ApplicantStatus.DOCUMENT_PASSED);
+        when(applicant.getStudentNo()).thenReturn("20210000");
+        when(applicant.getName()).thenReturn("TestName");
+        when(applicantService.getApplicantByStudentNo("20210000")).thenReturn(applicant);
+
+        // when
+        ResultCheckResponseDto result = recruitService.checkResult(request);
+
+        // then
+        assertNotNull(result);
+        assertTrue(result.getIsPassed());
+        verify(recruitRepository, times(1)).findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT);
+        verify(applicantService, times(1)).getApplicantByStudentNo("20210000");
+    }
+
+    @Test
+    @DisplayName("합격 결과 확인 - 실패 (확인 기간 아님)")
+    void checkResult_fail_inquiryPeriod() {
+        // given
+        Recruit recruit = mock(Recruit.class);
+        when(recruitRepository.findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT)).thenReturn(Optional.of(recruit));
+        String futureDateTime = LocalDateTime.now().plusHours(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        when(recruit.getValue()).thenReturn(futureDateTime);
+
+        ResultCheckRequestDto request = mock(ResultCheckRequestDto.class);
+        when(request.getType()).thenReturn(ResultCheckType.DOCUMENT_PASS);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            recruitService.checkResult(request);
+        });
+
+        // then
+        assertEquals(ErrorCode.INVALID_INQUIRY_PERIOD, exception.getErrorCode());
+        verify(recruitRepository, times(1)).findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT);
+    }
+
+    @Test
+    @DisplayName("합격 결과 확인 - 실패 (연락처 뒷자리 불일치)")
+    void checkResult_fail_contactMismatch() {
+        // given
+        Recruit recruit = mock(Recruit.class);
+        when(recruitRepository.findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT)).thenReturn(Optional.of(recruit));
+        String pastDateTime = LocalDateTime.now().minusHours(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        when(recruit.getValue()).thenReturn(pastDateTime);
+
+        ResultCheckRequestDto request = mock(ResultCheckRequestDto.class);
+        when(request.getType()).thenReturn(ResultCheckType.DOCUMENT_PASS);
+        when(request.getStudentNo()).thenReturn("20210000");
+        when(request.getContactLastDigit()).thenReturn("0000");
+
+        ApplicantDetailsResponseDto applicant = mock(ApplicantDetailsResponseDto.class);
+        when(applicant.getContact()).thenReturn("010-5678-1234");
+        when(applicantService.getApplicantByStudentNo("20210000")).thenReturn(applicant);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            recruitService.checkResult(request);
+        });
+
+        // then
+        assertEquals(ErrorCode.ARGUMENT_NOT_VALID, exception.getErrorCode());
+        verify(recruitRepository, times(1)).findByKey(ConfigKey.DOCUMENT_PASS_ANNOUNCEMENT);
+        verify(applicantService, times(1)).getApplicantByStudentNo("20210000");
+    }
+
 }


### PR DESCRIPTION
# [feat] 합격 조회 API 구현

## Issue
- #46 

## 변경 내용
- 서류, 최종 합격 조회 기능 구현
- 조회 타입에 따라 현재 조회 가능한지 여부 검증

## 구현 사항
- 학번으로 지원자 조회 로직 구현
- 학번으로 조회된 지원자의 연락처 뒷자리와 요청된 연락처 뒷자리가 일치한지 검증
- 서류, 최종 합격 조회 조건에 따라 현재 날짜가 합격 발표 기간 이후인지 검증하도록 구현