### PR TITLE
[fix] 지원자 상태 변경 오류

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
+++ b/src/main/java/dmu/dasom/api/domain/google/service/GoogleApiService.java
@@ -78,13 +78,13 @@ public class GoogleApiService {
         processSheetsUpdate(applicants, false);
     }
 
-    private int findRowIndexByStudentNo(String spreadSheetId, String sheetName, String studentNo){
+    public int findRowIndexByStudentNo(String spreadSheetId, String sheetName, String studentNo){
         try {
             List<List<Object>> rows = readSheet(spreadSheetId, sheetName + "!A:L"); // A열부터 L열까지 읽기
 
             for (int i = 0; i < rows.size(); i++){
                 List<Object> row = rows.get(i);
-                if(!row.isEmpty() && row.get(2).equals(studentNo)){
+                if(!row.isEmpty() && row.get(2).equals(studentNo)){ // 학번(Student No)이 3번째 열(A=0 기준)
                     return i + 1;
                 }
             }
@@ -174,5 +174,7 @@ public class GoogleApiService {
             throw new CustomException(ErrorCode.SHEET_WRITE_FAIL);
         }
     }
+
+
 
 }


### PR DESCRIPTION
# [fix] 지원자 상태 변경 오류

## Issue
- #51 

## 변경 내용
- 지원자 상태 변경 시 구글 스프레드 시트에 해당 지원자 없으면 오류가 발생
- 지원자 상태 변경 시 DB에는 지원자가 존재하고 구글 스프레드 시트에 업데이트하는 로직 추가

## 구현 사항
- 지원자 상태 변경 시 DB에는 지원자가 존재하고 구글 스프레드 시트에 업데이트하는 로직 추가

## 테스트
- 지원자 상태 변경 시 DB에 지원자가 존재하고 구글 스프레드 시트에 없으면 업데이트하는 테스트 케이스 추가