### PR TITLE
[fix] 면접 예약자 조회 API 면접일, 면접시간, 면접을 예약한 날짜와 시간 추가

### DIFF
--- a/src/main/java/dmu/dasom/api/domain/interview/dto/InterviewReservationApplicantResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/interview/dto/InterviewReservationApplicantResponseDto.java
@@ -4,6 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -37,4 +41,18 @@ public class InterviewReservationApplicantResponseDto {
 
     @Schema(description = "지원 동기", example = "동아리 활동을 통해 새로운 경험을 쌓고 싶어서 지원합니다.")
     private String reasonForApply;
+
+    @NotNull(message = "면접 일자는 필수 값입니다.")
+    @Schema(description = "면접 일자", example = "2025-03-12")
+    private LocalDate interviewDate;
+
+    @NotNull(message = "면접 시간은 필수 값입니다.")
+    @Schema(description = "면접 시간", example = "10:00")
+    private LocalTime interviewTime;
+
+    @NotNull(message = "면접 신청 날짜는 필수 값입니다.")
+    @Schema(description = "면접 신청 날짜", example = "2025-03-01T12:00:00")
+    private LocalDateTime appliedDate;
+
+
 }

--- a/src/main/java/dmu/dasom/api/domain/interview/dto/InterviewSlotResponseDto.java
+++ b/src/main/java/dmu/dasom/api/domain/interview/dto/InterviewSlotResponseDto.java
@@ -1,6 +1,7 @@
 package dmu.dasom.api.domain.interview.dto;
 
 import dmu.dasom.api.domain.interview.entity.InterviewSlot;
+import dmu.dasom.api.domain.interview.enums.InterviewStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -45,6 +46,10 @@ public class InterviewSlotResponseDto {
     @Schema(description = "현재 해당 슬롯에 예약된 지원자 수", example = "1")
     private Integer currentCandidates; // 현재 예약된 지원자 수
 
+    @NotNull(message = "면접 슬롯 상태는 필수 입력 값입니다.")
+    @Schema(description = "면접 슬롯의 상태 (ACTIVE, INACTIVE, CLOSED)", example = "ACTIVE")
+    private InterviewStatus interviewStatus; // 면접 슬롯 상태
+
     public InterviewSlotResponseDto(InterviewSlot slot){
         this.id = slot.getId();
         this.interviewDate = slot.getInterviewDate();
@@ -52,6 +57,7 @@ public class InterviewSlotResponseDto {
         this.endTime = slot.getEndTime();
         this.maxCandidates = slot.getMaxCandidates();
         this.currentCandidates = slot.getCurrentCandidates();
+        this.interviewStatus = slot.getInterviewStatus();
     }
 
 }

--- a/src/main/java/dmu/dasom/api/domain/interview/service/InterviewServiceImpl.java
+++ b/src/main/java/dmu/dasom/api/domain/interview/service/InterviewServiceImpl.java
@@ -155,6 +155,7 @@ public class InterviewServiceImpl implements InterviewService{
         return reservations.stream()
                 .map(reservation -> {
                     Applicant applicant = reservation.getApplicant();
+                    InterviewSlot slot = reservation.getSlot();
                     return InterviewReservationApplicantResponseDto.builder()
                             .applicantId(applicant.getId())
                             .applicantName(applicant.getName())
@@ -163,6 +164,9 @@ public class InterviewServiceImpl implements InterviewService{
                             .email(applicant.getEmail())
                             .activityWish(applicant.getActivityWish())
                             .reasonForApply(applicant.getReasonForApply())
+                            .interviewDate(slot.getInterviewDate())
+                            .interviewTime(slot.getStartTime())
+                            .appliedDate(reservation.getCreatedAt())
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
# [fix] 면접 예약자 조회 API 면접일, 면접시간, 면접을 예약한 날짜과 시간 추가

## Issue
- #59 

## 변경 내용
- 면접 예약자 조회시 면접시간, 면접일, 면접을 예약한 날짜와 시간을 반환

## 구현 사항
- InterviewReservationApplicantResponseDto에 면접시간, 면접일, 면접을 예약한 날짜와 시간 추가