### PR TITLE
[refactor] 이미지 저장 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    implementation 'software.amazon.awssdk:s3:2.28.23'
 }
 
 tasks.named('test') {

--- a/src/main/java/dmu/dasom/api/domain/common/exception/ErrorCode.java
+++ b/src/main/java/dmu/dasom/api/domain/common/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     SLOT_FULL(400, "C025", "해당 슬롯이 가득 찼습니다."),
     RESERVATION_NOT_FOUND(400, "C026", "예약을 찾을 수 없습니다."),
     SLOT_NOT_ACTIVE(400, "C027", "해당 슬롯이 비활성화 되었습니다."),
-    FILE_ENCODE_FAIL(400, "C028", "파일 인코딩에 실패하였습니다."),
+    FILE_UPLOAD_FAIL(400, "C028", "파일 업로드에 실패하였습니다."),
     RECRUITMENT_NOT_ACTIVE(400, "C029", "모집 기간이 아닙니다."),
     NOT_FOUND_PARTICIPANT(400, "C030", "참가자를 찾을 수 없습니다.")
     ;

--- a/src/main/java/dmu/dasom/api/global/R2/config/R2Config.java
+++ b/src/main/java/dmu/dasom/api/global/R2/config/R2Config.java
@@ -1,0 +1,35 @@
+package dmu.dasom.api.global.R2.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+
+@Configuration
+public class R2Config {
+
+    @Value("${cloudflare.r2.endpoint}")
+    private String endPoint;
+
+    @Value("${cloudflare.r2.access-key-id}")
+    private String accessKeyId;
+
+    @Value("${cloudflare.r2.secret-access-key}")
+    private String secretAccessKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+
+        return S3Client.builder()
+                .region(Region.of("auto")) // R2 does not require a specific region
+                .endpointOverride(URI.create(endPoint))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/dmu/dasom/api/global/R2/service/R2Service.java
+++ b/src/main/java/dmu/dasom/api/global/R2/service/R2Service.java
@@ -1,0 +1,56 @@
+package dmu.dasom.api.global.R2.service;
+
+import dmu.dasom.api.domain.common.exception.CustomException;
+import dmu.dasom.api.domain.common.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class R2Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloudflare.r2.bucket}")
+    private String bucket;
+
+    @Value("${cloudflare.r2.public-url}")
+    private String publicUrl;
+
+    public R2Service(S3Client s3Client) {
+        this.s3Client = s3Client;
+    }
+
+    public String uploadFile(MultipartFile file) {
+        String key = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(request,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
+        }
+        return publicUrl + "/" + key;
+    }
+
+    public void deleteFile(String fileUrl) {
+        String key = fileUrl.replace(publicUrl + "/", "");
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        s3Client.deleteObject(request);
+    }
+}

--- a/src/main/java/dmu/dasom/api/global/admin/controller/AdminFileController.java
+++ b/src/main/java/dmu/dasom/api/global/admin/controller/AdminFileController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,14 +41,14 @@ public class AdminFileController {
             ))
     })
     @PostMapping(value = "/upload", consumes = {"multipart/form-data"})
-    public ResponseEntity<Void> uploadFiles(
+    public ResponseEntity<List<FileResponseDto>> uploadFiles(
         @RequestParam("files") List<MultipartFile> files,
         @RequestParam("fileType") FileType fileType,
         @RequestParam("targetId") @Min(1) Long targetId
     ) {
-        fileService.uploadFiles(files, fileType, targetId);
-        return ResponseEntity.ok()
-            .build();
+        List<FileResponseDto> fileResponseDtos = fileService.uploadFiles(files, fileType, targetId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(fileResponseDtos);
     }
 
     @ApiResponses(value = {

--- a/src/main/java/dmu/dasom/api/global/file/dto/FileResponseDto.java
+++ b/src/main/java/dmu/dasom/api/global/file/dto/FileResponseDto.java
@@ -15,12 +15,11 @@ public class FileResponseDto {
     @NotNull
     private Long id;
 
+    @Schema(description = "파일 URL", example = "url")
+    @NotNull
+    private String encodedData;   // r2에 저장된 파일의 URL
+
     @Schema(description = "파일 형식", example = "image/png")
     @NotNull
     private String fileFormat;
-
-    @Schema(description = "인코딩 된 파일", example = "base64encoded")
-    @NotNull
-    private String encodedData;   // Base64 인코딩 데이터
-
 }

--- a/src/main/java/dmu/dasom/api/global/file/entity/FileEntity.java
+++ b/src/main/java/dmu/dasom/api/global/file/entity/FileEntity.java
@@ -21,8 +21,8 @@ public class FileEntity {
     private String originalName;
 
     @Lob
-    @Column(name = "ENCODED_DATA", nullable = false, columnDefinition = "CLOB")
-    private String encodedData;
+    @Column(name = "FILE_URL", nullable = false, columnDefinition = "CLOB")
+    private String fileUrl;
 
     @Column(name = "FILE_FORMAT", nullable = false)
     private String fileFormat;
@@ -41,7 +41,7 @@ public class FileEntity {
         return FileResponseDto.builder()
             .id(id)
             .fileFormat(fileFormat)
-            .encodedData(encodedData)
+            .encodedData(fileUrl)
             .build();
     }
 

--- a/src/main/resources/application-credentials.yml
+++ b/src/main/resources/application-credentials.yml
@@ -36,3 +36,10 @@ google:
       path: ${GOOGLE_CREDENTIALS_PATH}
   spreadsheet:
     id: ${GOOGLE_SPREADSHEET_ID}
+cloudflare:
+  r2:
+    endpoint: ${CLOUDFLARE_R2_ENDPOINT}
+    bucket: ${CLOUDFLARE_R2_BUCKET}
+    access-key-id: ${CLOUDFLARE_R2_ACCESS_KEY_ID}
+    secret-access-key: ${CLOUDFLARE_R2_SECRET_ACCESS_KEY}
+    public-url: ${CLOUDFLARE_R2_PUBLIC_URL}


### PR DESCRIPTION
# [refactor]이미지 저장 로직 수정

## Issue
- #90 

## 변경 내용
- Cloudflare r2 스토리지와 연동하여 뉴스 생성시 이미지는 클라우드 스토리지에 업로드 하도록 변경

## 체크리스트
- [x] 커밋 메시지가 컨벤션을 따르는가?
- [x] 로컬에서 빌드가 성공하는가?

## 테스트
- [x] 로컬에서 테스트 완료
- [x] 기존 기능에 영향 없음 확인
- [x] 다양한 브라우저에서 테스트 (필요시)
